### PR TITLE
Improve CLIP score computation

### DIFF
--- a/experiment_lib/continual_learning_experiment.py
+++ b/experiment_lib/continual_learning_experiment.py
@@ -487,41 +487,27 @@ class PredefinedSequenceExperiment(BaseExperiment):
         print(f"Total stats: {total_num_classes} classes & {total_num_samples} samples.")
     
     def _compute_clip_scores(self, dataset_name, indices, backbone, text_encoder, tokenizer, device, batch_size=512):
+        """Compute and store CLIP similarity scores for the given sample indices."""
         dset = self.train_datasets[dataset_name]
-        tfs, _, _ = create_transforms_list([
-            "Resize",
-            "CenterCrop",
-            "ToTensor",
-            "Normalize",
-        ], dset.PARAMS)
-        transform = torchvision.transforms.Compose(tfs)
+
+        subset = DataSubset(dset, np.array(indices), is_mask=False)
+        loader = self.make_dataloader(subset, train=False, custom_batch_size=batch_size)
+
         scores = self.clip_scores[dataset_name]
-        for start in range(0, len(indices), batch_size):
-            batch_idx = indices[start:start + batch_size]
-            images, texts = [], []
-            for idx in batch_idx:
-                img = dset._load_image(dset.data[idx])
-                images.append(transform(img))
-                if dset.caption_data is None:
-                    txt = dset.PARAMS["classes"][dset.targets[idx]]
-                else:
-                    txt = dset.caption_data[idx]
-                    if isinstance(txt, list):
-                        txt = txt[0]
-                texts.append(txt)
-            images = torch.stack(images).to(device)
+
+        for batch in loader:
+            images = batch["images"].to(device)
+            texts = batch["texts"]
             text_tokens = tokenizer(texts).to(device)
             with torch.no_grad(), torch.cuda.amp.autocast():
                 img_feat = torch.nn.functional.normalize(backbone(images), dim=-1)
                 txt_feat = torch.nn.functional.normalize(text_encoder.encode_text(text_tokens), dim=-1)
                 sims = (img_feat * txt_feat).sum(dim=1).cpu().numpy()
-            # for i, idx in enumerate(batch_idx):
-            #     scores[idx] = sims[i]
-            for i, idx in enumerate(batch_idx):
-                img_path = dset.data[idx]
-                scores[idx] = {
+
+            for i, idx in enumerate(batch["indices"]):
+                scores[int(idx)] = {
                     "score": float(sims[i]),
-                    "path": img_path,
+                    "path": batch["image_path"][i],
                     "text": texts[i],
                 }
 
@@ -532,7 +518,8 @@ class PredefinedSequenceExperiment(BaseExperiment):
             idcs = self.all_train_idcs[dataset_name][task]
             if idcs is None:
                 continue
-            need = [i for i in idcs if np.isnan(self.clip_scores[dataset_name][i])]
+            # Only compute CLIP scores for samples that do not yet have one
+            need = [i for i in idcs if i not in self.clip_scores[dataset_name]]
             if len(need):
                 self._compute_clip_scores(dataset_name, need, backbone, text_encoder, tokenizer, device, batch_size)
 
@@ -544,7 +531,9 @@ class PredefinedSequenceExperiment(BaseExperiment):
         for idx, ds in zip(buffer_idcs, buffer_ds):
             by_dataset.setdefault(ds, []).append(idx)
         for ds, idcs in by_dataset.items():
-            scores = self.clip_scores[ds][idcs]
+            scores = np.array([
+                self.clip_scores[ds][idx]["score"] for idx in idcs
+            ])
             keep = max(1, int(len(idcs) * ratio))
             order = np.argsort(scores)[-keep:]
             selected = [idcs[i] for i in order]

--- a/utils/training.py
+++ b/utils/training.py
@@ -610,10 +610,13 @@ def train(
                 idcs = experiment.all_train_idcs[ds][task]
                 if idcs is None or len(idcs) == 0:
                     continue
-                scores = experiment.clip_scores[ds][idcs]
-                valid = ~np.isnan(scores)
-                if np.any(valid):
-                    clip_means[ds] = float(np.mean(scores[valid]))
+                scores = [
+                    experiment.clip_scores[ds][idx]["score"]
+                    for idx in idcs
+                    if idx in experiment.clip_scores[ds]
+                ]
+                if len(scores) > 0:
+                    clip_means[ds] = float(np.mean(scores))
             task_stats['clip_score_means'] = clip_means
             experiment.dump_clip_scores_for_task(task, evaluator.log_folder)
         


### PR DESCRIPTION
## Summary
- compute CLIP scores using a DataLoader to leverage parallel image loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860510ca4348332ba08eccee63e9d15